### PR TITLE
Fix bug: Gesture detection (fixes #3)

### DIFF
--- a/VideoPlayer.xcodeproj/project.pbxproj
+++ b/VideoPlayer.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BEF43A962A65684800005ED3 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF43A952A65684800005ED3 /* View+.swift */; };
 		D4061C3D2A4B25B900CDD1FF /* ViewSizeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4061C2C2A4B25B900CDD1FF /* ViewSizeService.swift */; };
 		D4061C3E2A4B25B900CDD1FF /* StatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4061C2D2A4B25B900CDD1FF /* StatusService.swift */; };
 		D4061C402A4B25B900CDD1FF /* PlayerWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4061C302A4B25B900CDD1FF /* PlayerWidget.swift */; };
@@ -138,6 +139,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		BEF43A952A65684800005ED3 /* View+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
 		D4061C242A4B257800CDD1FF /* VideoPlayerContainer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = VideoPlayerContainer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4061C2C2A4B25B900CDD1FF /* ViewSizeService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewSizeService.swift; sourceTree = "<group>"; };
 		D4061C2D2A4B25B900CDD1FF /* StatusService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusService.swift; sourceTree = "<group>"; };
@@ -266,9 +268,18 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		BEF43A942A65684800005ED3 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				BEF43A952A65684800005ED3 /* View+.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
 		D4061C252A4B257800CDD1FF /* VideoPlayerContainer */ = {
 			isa = PBXGroup;
 			children = (
+				BEF43A942A65684800005ED3 /* Extension */,
 				D4061C2E2A4B25B900CDD1FF /* Container */,
 				D4061C312A4B25B900CDD1FF /* Core */,
 				D4061C362A4B25B900CDD1FF /* Overlayer */,
@@ -752,6 +763,7 @@
 				D4061C452A4B25B900CDD1FF /* ControlWidget.swift in Sources */,
 				D4061C3D2A4B25B900CDD1FF /* ViewSizeService.swift in Sources */,
 				D4061C482A4B25B900CDD1FF /* FeatureWidget.swift in Sources */,
+				BEF43A962A65684800005ED3 /* View+.swift in Sources */,
 				D4061C432A4B25B900CDD1FF /* Service.swift in Sources */,
 				D4061C462A4B25B900CDD1FF /* ToastWidget.swift in Sources */,
 				D4061C472A4B25B900CDD1FF /* PluginWidget.swift in Sources */,

--- a/VideoPlayerContainer/Extension/View+.swift
+++ b/VideoPlayerContainer/Extension/View+.swift
@@ -1,0 +1,84 @@
+//
+//  View+.swift
+//  TwoAndThreeColumn
+//
+//  Created by 陈伟斌 on 2023/7/17.
+//
+
+
+import SwiftUI
+
+
+#if os(macOS)
+struct MouseInsideModifier: ViewModifier {
+    let mouseIsInside: (Bool) -> Void
+    
+    init(_ mouseIsInside: @escaping (Bool) -> Void) {
+        self.mouseIsInside = mouseIsInside
+    }
+    
+    func body(content: Content) -> some View {
+        content.background(
+            GeometryReader { proxy in
+                Representable(mouseIsInside: mouseIsInside,
+                              frame: proxy.frame(in: .global))
+            }
+        )
+    }
+    
+    private struct Representable: NSViewRepresentable {
+        func makeNSView(context: NSViewRepresentableContext<Self>) -> NSView {
+            let view = NSView(frame: frame)
+            
+            let options: NSTrackingArea.Options = [
+                .mouseEnteredAndExited,
+                .inVisibleRect,
+                .activeInKeyWindow
+            ]
+            
+            let trackingArea = NSTrackingArea(rect: frame,
+                                              options: options,
+                                              owner: context.coordinator,
+                                              userInfo: nil)
+            
+            view.addTrackingArea(trackingArea)
+            
+            return view
+        }
+        
+        func updateNSView(_ nsView: NSView, context: NSViewRepresentableContext<Self>) {}
+        
+        let mouseIsInside: (Bool) -> Void
+        let frame: NSRect
+        
+        func makeCoordinator() -> Coordinator {
+            let coordinator = Coordinator()
+            coordinator.mouseIsInside = mouseIsInside
+            return coordinator
+        }
+        
+        class Coordinator: NSResponder {
+            var mouseIsInside: ((Bool) -> Void)?
+            
+            override func mouseEntered(with event: NSEvent) {
+                mouseIsInside?(true)
+            }
+            
+            override func mouseExited(with event: NSEvent) {
+                mouseIsInside?(false)
+            }
+        }
+        
+        static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+            nsView.trackingAreas.forEach { nsView.removeTrackingArea($0) }
+        }
+    }
+}
+
+extension View {
+    func whenHovered(_ mouseIsInside: @escaping (Bool) -> Void) -> some View {
+        modifier(MouseInsideModifier(mouseIsInside))
+    }
+}
+
+#endif

--- a/VideoPlayerContainer/Overlayer/GestureWidget.swift
+++ b/VideoPlayerContainer/Overlayer/GestureWidget.swift
@@ -187,12 +187,12 @@ public class GestureService : Service {
             .onChanged { [weak self] value in
                 guard let self = self else { return }
                 let event = GestureEvent(gesture: .rotate, action: .start, value: .rotate(value))
-                observable.send(event)
+                self.observable.send(event)
             }
             .onEnded { [weak self] value in
                 guard let self = self else { return }
                 let event = GestureEvent(gesture: .rotate, action: .end, value: .rotate(value))
-                observable.send(event)
+                self.observable.send(event)
             }
     }()
     
@@ -245,9 +245,11 @@ struct GestureWidget: View {
                             service.simultaneousRotationGesture ?? RotationGesture().onChanged{_ in}.onEnded{_ in}
                         )
                     )
-                    .onHover { changeOrEnd in
+                    #if os(macOS)
+                    .whenHovered { changeOrEnd in
                         service.handleHover(action: changeOrEnd ? .start : .end)
                     }
+                    #endif
             }
         }
     }


### PR DESCRIPTION
Due to the gesture detection view layer being at the bottom of the ZStack, the mouse entering other control elements is also considered as leaving the gesture detection's Color.clear.contentShape(Rectangle())

[Solution Reference](https://gist.github.com/importRyan/c668904b0c5442b80b6f38a980595031)